### PR TITLE
Ajusta espaçamento da hero no mobile

### DIFF
--- a/contato.html
+++ b/contato.html
@@ -68,9 +68,9 @@
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO HERO CONTATO -->
     <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative h-[320px] w-full">
+      <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Luzes verdes representando conexões" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex h-full max-w-4xl flex-col justify-center gap-4 px-4 py-12 lg:px-8">
+        <div class="relative mx-auto flex max-w-4xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Contato</p>
           <h1 class="font-display text-5xl uppercase leading-tight">Ative uma conversa</h1>
           <p class="max-w-2xl text-lg text-foreground/80">Queremos colaborar com pessoas e organizações que buscam regenerar ecossistemas humanos.</p>

--- a/conteudos.html
+++ b/conteudos.html
@@ -68,9 +68,9 @@
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO HERO CONTEÚDOS -->
     <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative h-[360px] w-full">
+      <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Texturas urbanas abstratas" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex h-full max-w-6xl flex-col justify-center gap-4 px-4 py-12 lg:px-8">
+        <div class="relative mx-auto flex max-w-6xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Conteúdos</p>
           <h1 class="font-display text-5xl uppercase leading-tight">Programas e narrativas em evolução</h1>
           <p class="max-w-3xl text-lg text-foreground/80">Uma curadoria contínua de experiências para nutrir corpo, mente e espírito. Escolha a trilha que conversa com o seu momento.</p>

--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO HERO -->
     <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative h-[520px] w-full">
+      <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Texturas orgânicas e formas abstratas" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex h-full max-w-6xl flex-col justify-center gap-6 px-4 py-12 lg:flex-row lg:items-center lg:px-8">
+        <div class="relative mx-auto flex max-w-6xl flex-col justify-center gap-6 px-4 py-24 sm:py-28 lg:flex-row lg:items-center lg:gap-10 lg:px-8 lg:py-20">
           <div class="max-w-2xl space-y-4">
             <p class="font-semibold uppercase tracking-[0.25em] text-accent">Biologia evolutiva na prática</p>
             <h1 class="font-display text-5xl uppercase leading-tight md:text-6xl">Reescrevendo narrativas de bem-estar</h1>

--- a/manifesto.html
+++ b/manifesto.html
@@ -68,9 +68,9 @@
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO MANIFESTO HERO -->
     <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative h-[360px] w-full">
+      <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Formas abstratas em verde e preto" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex h-full max-w-5xl flex-col justify-center gap-4 px-4 py-12 lg:px-8">
+        <div class="relative mx-auto flex max-w-5xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Manifesto</p>
           <h1 class="font-display text-5xl uppercase leading-tight">Compromissos para futuros possíveis</h1>
           <p class="max-w-2xl text-lg text-foreground/80">Uma declaração viva que orienta nossas decisões coletivas, respeitando a complexidade da vida e celebrando o potencial humano.</p>

--- a/sobre.html
+++ b/sobre.html
@@ -68,9 +68,9 @@
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO HERO SOBRE -->
     <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative h-[360px] w-full">
+      <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Formas abstratas representando colaboração" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex h-full max-w-6xl flex-col justify-center gap-4 px-4 py-12 lg:px-8">
+        <div class="relative mx-auto flex max-w-6xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Sobre nós</p>
           <h1 class="font-display text-5xl uppercase leading-tight">Laboratório de futuros regenerativos</h1>
           <p class="max-w-3xl text-lg text-foreground/80">Somos estrategistas, cientistas, educadores e artistas experimentando novas maneiras de viver em sintonia com a natureza.</p>


### PR DESCRIPTION
## Resumo
- ajusta a estrutura das seções hero para usar altura fluida com padding responsivo
- evita que o menu móvel sobreponha o conteúdo inicial em todas as páginas principais

## Testes
- inspeção manual em viewport mobile (Chrome via Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68cc7039e0f48328b4fc4430528a6a9f