### PR TITLE
Improve mobile navigation menu interactions

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -56,3 +56,41 @@ body {
   font-display: swap;
   src: url('https://fonts.gstatic.com/s/leaguegothic/v9/CSRg4x8UC4p2Ql0Xv6A.woff2') format('woff2');
 }
+
+@media (max-width: 1023px) {
+  [data-nav-mobile] {
+    position: fixed;
+    top: var(--mobile-nav-top, 76px);
+    right: 0;
+    left: 0;
+    z-index: 40;
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(0, 0, 0, 0.92);
+    backdrop-filter: blur(14px);
+    box-shadow: 0 18px 40px -20px rgba(0, 0, 0, 0.6);
+    transform: translateY(-12px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 180ms ease, transform 220ms ease;
+  }
+
+  [data-nav-mobile].mobile-nav-open {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  [data-nav-mobile] .mobile-nav__link {
+    color: #ffffff;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-shadow: 0 0 12px rgba(255, 255, 255, 0.55);
+    transition: background-color 200ms ease, color 200ms ease;
+  }
+
+  [data-nav-mobile] .mobile-nav__link:hover,
+  [data-nav-mobile] .mobile-nav__link:focus-visible {
+    background-color: rgba(255, 255, 255, 0.22);
+    color: #ffffff;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,39 +1,76 @@
 (function() {
   const menuButton = document.querySelector('[data-menu-button]');
-  const navs = Array.from(document.querySelectorAll('[data-nav]'));
+  const mobileNav = document.querySelector('[data-nav-mobile]');
   const overlay = document.querySelector('[data-overlay]');
+  const header = menuButton ? menuButton.closest('header') : null;
 
-  if (!menuButton || navs.length === 0) {
+  if (!menuButton || !mobileNav) {
     return;
   }
 
-  const isMobileNav = (nav) => nav.tagName === 'NAV' && nav.classList.contains('lg:hidden');
-  const mobileNav = navs.find(isMobileNav);
+  let lastFocusedElement = null;
+
+  const updateNavTop = () => {
+    if (header instanceof HTMLElement) {
+      const { bottom } = header.getBoundingClientRect();
+      const offset = Math.max(0, Math.round(bottom));
+      mobileNav.style.setProperty('--mobile-nav-top', `${offset}px`);
+    } else {
+      mobileNav.style.removeProperty('--mobile-nav-top');
+    }
+  };
+
+  const focusFirstLink = () => {
+    const firstFocusable = mobileNav.querySelector('a[href], button:not([disabled]), [tabindex="0"]');
+    if (firstFocusable instanceof HTMLElement) {
+      firstFocusable.focus();
+    }
+  };
 
   const openNav = () => {
-    if (mobileNav) {
-      mobileNav.classList.remove('hidden');
-    }
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : menuButton;
+    updateNavTop();
+    mobileNav.classList.remove('hidden');
+    mobileNav.classList.add('mobile-nav-open');
     menuButton.setAttribute('aria-expanded', 'true');
     if (overlay) {
       overlay.classList.remove('hidden');
     }
-    mobileNav?.querySelector('a, button')?.focus();
+    document.body.classList.add('overflow-hidden');
+    focusFirstLink();
   };
 
   const closeNav = () => {
-    if (mobileNav) {
+    const wasOpen = mobileNav.classList.contains('mobile-nav-open');
+    if (wasOpen) {
+      const hideNav = () => {
+        mobileNav.classList.add('hidden');
+      };
+      mobileNav.addEventListener('transitionend', hideNav, { once: true });
+      // Fallback in case the transition is interrupted.
+      window.setTimeout(() => {
+        if (!mobileNav.classList.contains('mobile-nav-open')) {
+          mobileNav.classList.add('hidden');
+        }
+      }, 250);
+    } else {
       mobileNav.classList.add('hidden');
     }
+    mobileNav.classList.remove('mobile-nav-open');
     menuButton.setAttribute('aria-expanded', 'false');
     if (overlay) {
       overlay.classList.add('hidden');
     }
-    menuButton.focus();
+    document.body.classList.remove('overflow-hidden');
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    } else {
+      menuButton.focus();
+    }
   };
 
   const toggleNav = () => {
-    const shouldOpen = mobileNav ? mobileNav.classList.contains('hidden') : true;
+    const shouldOpen = mobileNav.classList.contains('hidden');
     if (shouldOpen) {
       openNav();
     } else {
@@ -44,7 +81,7 @@
   menuButton.addEventListener('click', toggleNav);
 
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && mobileNav && !mobileNav.classList.contains('hidden')) {
+    if (event.key === 'Escape' && mobileNav.classList.contains('mobile-nav-open')) {
       closeNav();
     }
   });
@@ -53,11 +90,32 @@
     overlay.addEventListener('click', closeNav);
   }
 
-  if (mobileNav) {
-    mobileNav.addEventListener('click', (event) => {
-      if (event.target instanceof Element && event.target.tagName === 'A') {
-        closeNav();
-      }
-    });
+  mobileNav.addEventListener('click', (event) => {
+    const link = event.target instanceof Element ? event.target.closest('a') : null;
+    if (link) {
+      closeNav();
+    }
+  });
+
+  const desktopMediaQuery = window.matchMedia('(min-width: 1024px)');
+  const handleViewportChange = (event) => {
+    if (event.matches && mobileNav.classList.contains('mobile-nav-open')) {
+      closeNav();
+    }
+  };
+
+  if (typeof desktopMediaQuery.addEventListener === 'function') {
+    desktopMediaQuery.addEventListener('change', handleViewportChange);
+  } else {
+    desktopMediaQuery.addListener(handleViewportChange);
   }
+
+  const handleResize = () => {
+    if (mobileNav.classList.contains('mobile-nav-open')) {
+      updateNavTop();
+    }
+  };
+
+  window.addEventListener('resize', handleResize);
+  window.addEventListener('scroll', handleResize);
 })();

--- a/contato.html
+++ b/contato.html
@@ -46,7 +46,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
         </svg>
       </button>
-      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav>
+      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav data-nav-desktop>
         <a class="focus-visible transition hover:text-accent" href="/">Home</a>
         <a class="focus-visible transition hover:text-accent" href="/manifesto.html">Manifesto</a>
         <a class="focus-visible transition hover:text-accent" href="/conteudos.html">Conteúdos</a>
@@ -54,13 +54,13 @@
         <a class="focus-visible text-accent transition hover:text-accent" href="/contato.html" aria-current="page">Contato</a>
       </nav>
     </div>
-    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav>
+    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav data-nav-mobile>
       <ul class="space-y-2 text-lg font-medium">
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/">Home</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/manifesto.html">Manifesto</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/conteudos.html">Conteúdos</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/sobre.html">Sobre</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10 text-accent" href="/contato.html" aria-current="page">Contato</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/">Home</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/manifesto.html">Manifesto</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/conteudos.html">Conteúdos</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/sobre.html">Sobre</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition text-accent" href="/contato.html" aria-current="page">Contato</a></li>
       </ul>
     </nav>
   </header>

--- a/conteudos.html
+++ b/conteudos.html
@@ -46,7 +46,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
         </svg>
       </button>
-      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav>
+      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav data-nav-desktop>
         <a class="focus-visible transition hover:text-accent" href="/">Home</a>
         <a class="focus-visible transition hover:text-accent" href="/manifesto.html">Manifesto</a>
         <a class="focus-visible text-accent transition hover:text-accent" href="/conteudos.html" aria-current="page">Conteúdos</a>
@@ -54,13 +54,13 @@
         <a class="focus-visible transition hover:text-accent" href="/contato.html">Contato</a>
       </nav>
     </div>
-    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav>
+    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav data-nav-mobile>
       <ul class="space-y-2 text-lg font-medium">
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/">Home</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/manifesto.html">Manifesto</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10 text-accent" href="/conteudos.html" aria-current="page">Conteúdos</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/sobre.html">Sobre</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/contato.html">Contato</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/">Home</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/manifesto.html">Manifesto</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition text-accent" href="/conteudos.html" aria-current="page">Conteúdos</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/sobre.html">Sobre</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/contato.html">Contato</a></li>
       </ul>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
         </svg>
       </button>
-      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav>
+      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav data-nav-desktop>
         <a class="focus-visible transition hover:text-accent" href="/">Home</a>
         <a class="focus-visible transition hover:text-accent" href="/manifesto.html">Manifesto</a>
         <a class="focus-visible transition hover:text-accent" href="/conteudos.html">Conteúdos</a>
@@ -54,13 +54,13 @@
         <a class="focus-visible transition hover:text-accent" href="/contato.html">Contato</a>
       </nav>
     </div>
-    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav>
+    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav data-nav-mobile>
       <ul class="space-y-2 text-lg font-medium">
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/">Home</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/manifesto.html">Manifesto</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/conteudos.html">Conteúdos</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/sobre.html">Sobre</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/contato.html">Contato</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/">Home</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/manifesto.html">Manifesto</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/conteudos.html">Conteúdos</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/sobre.html">Sobre</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/contato.html">Contato</a></li>
       </ul>
     </nav>
   </header>

--- a/manifesto.html
+++ b/manifesto.html
@@ -46,7 +46,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
         </svg>
       </button>
-      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav>
+      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav data-nav-desktop>
         <a class="focus-visible transition hover:text-accent" href="/">Home</a>
         <a class="focus-visible text-accent transition hover:text-accent" href="/manifesto.html" aria-current="page">Manifesto</a>
         <a class="focus-visible transition hover:text-accent" href="/conteudos.html">Conteúdos</a>
@@ -54,13 +54,13 @@
         <a class="focus-visible transition hover:text-accent" href="/contato.html">Contato</a>
       </nav>
     </div>
-    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav>
+    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav data-nav-mobile>
       <ul class="space-y-2 text-lg font-medium">
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/">Home</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10 text-accent" href="/manifesto.html" aria-current="page">Manifesto</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/conteudos.html">Conteúdos</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/sobre.html">Sobre</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/contato.html">Contato</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/">Home</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition text-accent" href="/manifesto.html" aria-current="page">Manifesto</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/conteudos.html">Conteúdos</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/sobre.html">Sobre</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/contato.html">Contato</a></li>
       </ul>
     </nav>
   </header>

--- a/sobre.html
+++ b/sobre.html
@@ -46,7 +46,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
         </svg>
       </button>
-      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav>
+      <nav class="hidden flex-1 justify-end gap-8 text-sm font-medium lg:flex" data-nav data-nav-desktop>
         <a class="focus-visible transition hover:text-accent" href="/">Home</a>
         <a class="focus-visible transition hover:text-accent" href="/manifesto.html">Manifesto</a>
         <a class="focus-visible transition hover:text-accent" href="/conteudos.html">Conteúdos</a>
@@ -54,13 +54,13 @@
         <a class="focus-visible transition hover:text-accent" href="/contato.html">Contato</a>
       </nav>
     </div>
-    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav>
+    <nav class="hidden border-t border-white/10 bg-background px-4 pb-6 pt-4 lg:hidden" data-nav data-nav-mobile>
       <ul class="space-y-2 text-lg font-medium">
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/">Home</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/manifesto.html">Manifesto</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/conteudos.html">Conteúdos</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10 text-accent" href="/sobre.html" aria-current="page">Sobre</a></li>
-        <li><a class="focus-visible block rounded-md px-2 py-2 transition hover:bg-white/10" href="/contato.html">Contato</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/">Home</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/manifesto.html">Manifesto</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/conteudos.html">Conteúdos</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition text-accent" href="/sobre.html" aria-current="page">Sobre</a></li>
+        <li><a class="focus-visible mobile-nav__link block rounded-md px-2 py-2 transition" href="/contato.html">Contato</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- enhance the mobile navigation script to reliably toggle the menu, control focus, lock scroll and close on viewport changes
- restyle the mobile menu panel with a blurred overlay effect and brighter link styling for better contrast
- update page headers to use the new mobile navigation hooks across all sections

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc785122748328886364cc92a0b8bc