### PR TITLE
Fix mobile menu stacking so hamburger button stays clickable

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -11,6 +11,20 @@ body {
   color: #141414;
 }
 
+header {
+  position: relative;
+  z-index: 50;
+}
+
+[data-overlay] {
+  pointer-events: none;
+  z-index: 40;
+}
+
+[data-overlay]:not(.hidden) {
+  pointer-events: auto;
+}
+
 .font-display {
   font-family: 'League Gothic', 'Poppins', sans-serif;
   letter-spacing: 0.05em;
@@ -63,7 +77,7 @@ body {
     top: var(--mobile-nav-top, 76px);
     right: 0;
     left: 0;
-    z-index: 40;
+    z-index: 60;
     border-top: 1px solid rgba(255, 255, 255, 0.18);
     background: rgba(0, 0, 0, 0.92);
     backdrop-filter: blur(14px);


### PR DESCRIPTION
## Summary
- elevate the header above the page overlay so the hamburger button is never covered
- ensure the overlay only captures pointer events when visible and keep the mobile nav above it

## Testing
- python -m http.server 8000 (manually verified mobile menu opens and closes on Chromium mobile emulation)


------
https://chatgpt.com/codex/tasks/task_e_68cc7f848adc8328b0e898105654a8f3