### PR TITLE
Implement fallback loading for featured content

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,17 @@ A página inicial foi reorganizada em blocos independentes. Os textos podem ser 
 
 ### Conteúdos em destaque
 - Os cards são gerados dinamicamente a partir do arquivo `assets/data/conteudos.json`.
-- Cada item do array deve conter os campos:
-  - `titulo` (string)
-  - `descricao` (string curta)
-  - `imagem` (URL absoluta ou caminho relativo)
-  - `alt` (texto alternativo da imagem)
-  - `link` (URL para “Ler mais”)
-- Basta editar o JSON e recarregar a página. Em caso de erro de carregamento, uma mensagem orienta a verificar o arquivo.
+- Cada item do array deve conter os campos obrigatórios:
+  - `titulo` — texto curto em formato de string.
+  - `descricao` — resumo provocativo com até 1 ou 2 frases.
+  - `imagem` — URL completa (ex.: `https://placehold.co/600x400`) ou caminho relativo dentro de `assets/img/`.
+  - `link` — destino do botão “Ler mais” (página interna ou externa).
+- Opcionalmente, inclua `alt` para personalizar o texto alternativo da imagem.
+- Para adicionar ou editar conteúdos:
+  1. Abra `assets/data/conteudos.json` em um editor de texto.
+  2. Duplique um dos objetos existentes (cada objeto é separado por vírgulas) e ajuste os campos.
+  3. Salve o arquivo e recarregue o `index.html` no navegador para visualizar as mudanças.
+- Se o JSON estiver vazio, malformatado ou indisponível, a Home usa automaticamente três cards padrão definidos no script inline do `index.html`. Uma mensagem informativa aparece abaixo dos cards indicando se os dados vieram do arquivo ou do fallback.
 
 ### Bloco interativo/reflexão
 - Os botões possuem atributos `data-reflexao` (`cacar`, `cooperar`, `fugir`).

--- a/assets/data/conteudos.json
+++ b/assets/data/conteudos.json
@@ -1,23 +1,20 @@
 [
   {
-    "titulo": "Rituais circadianos para tempos digitais",
-    "descricao": "Pequenas práticas que reprogramam o corpo para responder melhor a telas, trabalho remoto e noites pouco escuras.",
-    "imagem": "https://images.unsplash.com/photo-1506126613408-eca07ce68773?auto=format&fit=crop&w=800&q=80",
-    "alt": "Pessoa observando o nascer do sol em meio à natureza",
+    "titulo": "Ecossistemas de cuidado urbano",
+    "descricao": "Práticas micro que reencantam a vida nas cidades e criam laços de regeneração coletiva.",
+    "imagem": "https://placehold.co/600x400/0f172a/ffffff?text=%3Bparadigma",
+    "link": "/manifesto.html"
+  },
+  {
+    "titulo": "Fisiologia da esperança",
+    "descricao": "Como o corpo responde a pequenas vitórias e por que celebrar importa para a evolução cultural.",
+    "imagem": "https://placehold.co/600x400/14532d/ffffff?text=%3Bparadigma",
     "link": "/conteudos.html"
   },
   {
-    "titulo": "Tecnologia como extensão do corpo",
-    "descricao": "Podcast sobre como próteses, apps e inteligência artificial recriam ecologias de cooperação ancestrais.",
-    "imagem": "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=800&q=80",
-    "alt": "Mãos humanas interagindo com uma interface holográfica",
-    "link": "/conteudos.html"
-  },
-  {
-    "titulo": "Mapas afetivos da cidade",
-    "descricao": "Guia em PDF para cartografar laços de cuidado, consumo e mobilidade sob uma lente evolutiva.",
-    "imagem": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=800&q=80",
-    "alt": "Vista aérea de uma cidade com ruas iluminadas",
+    "titulo": "Rituais circadianos em 15 minutos",
+    "descricao": "Um roteiro rápido para resetar o relógio biológico em meio ao caos digital.",
+    "imagem": "https://placehold.co/600x400/334155/ffffff?text=%3Bparadigma",
     "link": "/conteudos.html"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -343,78 +343,116 @@
       const conteudosGrid = document.querySelector('[data-conteudos-grid]');
       const conteudosFeedback = document.querySelector('[data-conteudos-feedback]');
       const conteudosEndpoint = '/assets/data/conteudos.json';
-      if (conteudosGrid) {
-        fetch(conteudosEndpoint)
-          .then((response) => {
-            if (!response.ok) {
-              throw new Error('Não foi possível carregar os conteúdos.');
-            }
-            return response.json();
-          })
-          .then((data) => {
-            if (!Array.isArray(data) || data.length === 0) {
-              if (conteudosFeedback) {
-                conteudosFeedback.textContent = 'Adicione conteúdos no arquivo assets/data/conteudos.json para preencher esta seção.';
-              }
-              return;
-            }
-            const fragment = document.createDocumentFragment();
-            data.forEach((item) => {
-              const card = document.createElement('article');
-              card.className = 'flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg';
+      const conteudosFallback = [
+        {
+          titulo: 'Ecossistemas de cuidado urbano',
+          descricao: 'Práticas micro que reencantam a vida nas cidades e criam laços de regeneração coletiva.',
+          imagem: 'https://placehold.co/600x400/0f172a/ffffff?text=%3Bparadigma',
+          link: '/manifesto.html',
+        },
+        {
+          titulo: 'Fisiologia da esperança',
+          descricao: 'Como o corpo responde a pequenas vitórias e por que celebrar importa para a evolução cultural.',
+          imagem: 'https://placehold.co/600x400/14532d/ffffff?text=%3Bparadigma',
+          link: '/conteudos.html',
+        },
+        {
+          titulo: 'Rituais circadianos em 15 minutos',
+          descricao: 'Um roteiro rápido para resetar o relógio biológico em meio ao caos digital.',
+          imagem: 'https://placehold.co/600x400/334155/ffffff?text=%3Bparadigma',
+          link: '/conteudos.html',
+        },
+      ];
 
-              const figure = document.createElement('div');
-              figure.className = 'relative h-48 w-full bg-slate-200';
-              if (item.imagem) {
-                const img = document.createElement('img');
-                img.src = item.imagem;
-                img.alt = item.alt || item.titulo || 'Conteúdo em destaque';
-                img.loading = 'lazy';
-                img.className = 'h-full w-full object-cover';
-                figure.appendChild(img);
-              } else {
-                figure.innerHTML = '<span class="sr-only">Imagem ilustrativa do conteúdo</span>';
-              }
-              card.appendChild(figure);
+      const renderConteudos = (items) => {
+        const fragment = document.createDocumentFragment();
+        items.forEach((item) => {
+          const card = document.createElement('article');
+          card.className = 'flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg';
 
-              const body = document.createElement('div');
-              body.className = 'flex flex-1 flex-col gap-4 p-6';
+          const figure = document.createElement('div');
+          figure.className = 'relative h-48 w-full bg-slate-200';
+          if (item.imagem) {
+            const img = document.createElement('img');
+            img.src = item.imagem;
+            img.alt = item.alt || item.titulo || 'Conteúdo em destaque';
+            img.loading = 'lazy';
+            img.decoding = 'async';
+            img.className = 'h-full w-full object-cover';
+            figure.appendChild(img);
+          } else {
+            figure.innerHTML = '<span class="sr-only">Imagem ilustrativa do conteúdo</span>';
+          }
+          card.appendChild(figure);
 
-              if (item.titulo) {
-                const title = document.createElement('h3');
-                title.className = 'font-display text-2xl uppercase text-background';
-                title.textContent = item.titulo;
-                body.appendChild(title);
-              }
+          const body = document.createElement('div');
+          body.className = 'flex flex-1 flex-col gap-4 p-6';
 
-              if (item.descricao) {
-                const description = document.createElement('p');
-                description.className = 'text-sm text-slate-600';
-                description.textContent = item.descricao;
-                body.appendChild(description);
-              }
+          if (item.titulo) {
+            const title = document.createElement('h3');
+            title.className = 'font-display text-2xl uppercase text-background';
+            title.textContent = item.titulo;
+            body.appendChild(title);
+          }
 
-              const linkWrapper = document.createElement('div');
-              linkWrapper.className = 'mt-auto';
-              const link = document.createElement('a');
-              link.className = 'focus-visible inline-flex items-center justify-center rounded-full bg-background px-6 py-2 text-sm font-semibold text-foreground transition hover:bg-accent hover:text-background';
-              link.textContent = 'Ler mais';
-              link.href = item.link || '#';
-              link.setAttribute('aria-label', item.titulo ? `Ler mais sobre ${item.titulo}` : 'Ler conteúdo');
-              linkWrapper.appendChild(link);
-              body.appendChild(linkWrapper);
+          if (item.descricao) {
+            const description = document.createElement('p');
+            description.className = 'text-sm text-slate-600';
+            description.textContent = item.descricao;
+            body.appendChild(description);
+          }
 
-              card.appendChild(body);
-              fragment.appendChild(card);
-            });
-            conteudosGrid.appendChild(fragment);
-          })
-          .catch(() => {
-            if (conteudosFeedback) {
-              conteudosFeedback.textContent = 'Não foi possível carregar os conteúdos. Verifique se o arquivo assets/data/conteudos.json está acessível.';
-            }
-          });
-      }
+          const linkWrapper = document.createElement('div');
+          linkWrapper.className = 'mt-auto';
+          const link = document.createElement('a');
+          link.className = 'focus-visible inline-flex items-center justify-center rounded-full bg-background px-6 py-2 text-sm font-semibold text-foreground transition hover:bg-accent hover:text-background';
+          link.textContent = 'Ler mais';
+          link.href = item.link || '#';
+          link.setAttribute('aria-label', item.titulo ? `Ler mais sobre ${item.titulo}` : 'Ler conteúdo');
+          linkWrapper.appendChild(link);
+          body.appendChild(linkWrapper);
+
+          card.appendChild(body);
+          fragment.appendChild(card);
+        });
+        conteudosGrid.appendChild(fragment);
+      };
+
+      const carregarConteudos = async () => {
+        if (!conteudosGrid) {
+          return;
+        }
+
+        let dados = null;
+        let utilizouFallback = false;
+
+        try {
+          const response = await fetch(conteudosEndpoint, { cache: 'no-store' });
+          if (!response.ok) {
+            throw new Error('Não foi possível carregar os conteúdos.');
+          }
+          dados = await response.json();
+        } catch (error) {
+          dados = conteudosFallback;
+          utilizouFallback = true;
+        }
+
+        if (!Array.isArray(dados) || dados.length === 0) {
+          dados = conteudosFallback;
+          utilizouFallback = true;
+        }
+
+        conteudosGrid.innerHTML = '';
+        renderConteudos(dados);
+
+        if (conteudosFeedback) {
+          conteudosFeedback.textContent = utilizouFallback
+            ? 'Conteúdos carregados automaticamente. Atualize assets/data/conteudos.json para personalizar esta seção.'
+            : 'Conteúdos carregados do arquivo assets/data/conteudos.json.';
+        }
+      };
+
+      carregarConteudos();
 
       const anoFooter = document.getElementById('ano-footer');
       if (anoFooter) {


### PR DESCRIPTION
## Summary
- replace the featured content loader on the home page with a resilient fetch routine that falls back to predefined cards when the JSON file is unavailable or empty
- populate `assets/data/conteudos.json` with three sample highlighted cards using placeholder imagery and links
- expand the README with simple instructions on how to update the featured content data file and note the automatic fallback behavior

## Testing
- not run (static site project)


------
https://chatgpt.com/codex/tasks/task_e_68cdcba4c9ec8328bae739dbe12c7998