### PR TITLE
Open featured content links in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,6 +371,8 @@
           link.className = 'focus-visible inline-flex items-center justify-center rounded-full bg-background px-4 py-2 text-xs font-semibold text-foreground transition hover:bg-accent hover:text-background md:px-6 md:text-sm';
           link.textContent = 'Ler mais';
           link.href = item.link || '#';
+          link.target = '_blank';
+          link.rel = 'noopener noreferrer';
           link.setAttribute('aria-label', item.titulo ? `Ler mais sobre ${item.titulo}` : 'Ler conteúdo');
           linkWrapper.appendChild(link);
           body.appendChild(linkWrapper);


### PR DESCRIPTION
## Summary
- ensure the featured content card links open in a new tab using target="_blank" and rel="noopener noreferrer"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1b6f258808328a50e77d5509d76d1