### PR TITLE
Add background image to manifesto section

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,16 @@
       </div>
     </section>
 
-    <section class="mx-auto max-w-5xl px-4 py-16 lg:px-8" aria-labelledby="manifesto-heading">
+    <section
+      class="relative mx-auto max-w-5xl overflow-hidden px-4 py-16 lg:px-8"
+      aria-labelledby="manifesto-heading"
+      style="
+        background-image: linear-gradient(rgba(9, 9, 11, 0.55), rgba(9, 9, 11, 0.55)), url('/assets/img/bg-manifesto.jpg');
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+      "
+    >
       <div class="space-y-6 rounded-3xl bg-white p-8 shadow-lg">
         <div class="space-y-2">
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Manifesto</p>


### PR DESCRIPTION
## Summary
- apply the manifesto background image with a dark overlay for legibility
- ensure the section background covers the full area with centered positioning

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1c52859148328a8b5fc653a65dbf3