### PR TITLE
Ajusta background da seção Manifesto

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
     </section>
 
     <section
-      class="relative mx-auto max-w-5xl overflow-hidden px-4 py-16 lg:px-8"
+      class="relative overflow-hidden px-4 py-16 lg:px-8"
       aria-labelledby="manifesto-heading"
       style="
         background-image: linear-gradient(rgba(9, 9, 11, 0.55), rgba(9, 9, 11, 0.55)), url('/assets/img/bg-manifesto.jpg');
@@ -137,12 +137,13 @@
         background-repeat: no-repeat;
       "
     >
-      <div class="space-y-6 rounded-3xl bg-white p-8 shadow-lg">
-        <div class="space-y-2">
-          <p class="font-semibold uppercase tracking-[0.3em] text-accent">Manifesto</p>
-          <h2 id="manifesto-heading" class="font-display text-4xl uppercase text-background">Respirar história para mover futuros</h2>
-        </div>
-        <div class="space-y-4 text-slate-700">
+      <div class="mx-auto max-w-5xl">
+        <div class="space-y-6 rounded-3xl bg-white p-8 shadow-lg">
+          <div class="space-y-2">
+            <p class="font-semibold uppercase tracking-[0.3em] text-accent">Manifesto</p>
+            <h2 id="manifesto-heading" class="font-display text-4xl uppercase text-background">Respirar história para mover futuros</h2>
+          </div>
+          <div class="space-y-4 text-slate-700">
           <p>
             Somos uma comunidade que lê a biologia evolutiva como mapa para o agora. Investigamos como heranças ancestrais moldam comportamentos, emoções e escolhas, sem romantizar o passado nem idealizar o futuro.
           </p>
@@ -159,6 +160,7 @@
             class="focus-visible inline-flex items-center justify-center rounded-full bg-background px-8 py-3 font-semibold text-foreground transition hover:bg-accent hover:text-background"
           >Ler manifesto completo</a>
         </div>
+      </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- remove a limitação de largura da seção Manifesto para permitir que o background ocupe toda a área
- adiciona um contêiner interno para manter o card centralizado sobre o novo fundo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c8647ec8832891c71959406d4cc3