### PR TITLE
Ajusta animação e conteúdo da seção Manifesto

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
     </section>
 
     <section
-      class="relative overflow-hidden px-4 py-16 opacity-0 translate-y-8 transition-all duration-700 ease-out lg:px-8"
+      class="relative overflow-hidden px-4 py-16 opacity-0 translate-y-8 transition-all duration-1000 ease-[cubic-bezier(0.16,1,0.3,1)] lg:px-8"
       aria-labelledby="manifesto-heading"
       data-animate-on-scroll
       style="
@@ -140,7 +140,7 @@
     >
       <div class="mx-auto max-w-5xl">
         <div
-          class="space-y-6 rounded-3xl bg-white/80 p-8 shadow-lg backdrop-blur-sm opacity-0 translate-y-6 scale-95 transition-all duration-700 ease-out"
+          class="space-y-6 rounded-3xl bg-white/60 p-8 shadow-lg backdrop-blur-sm opacity-0 translate-y-6 scale-95 transition-all duration-1000 ease-[cubic-bezier(0.16,1,0.3,1)]"
           data-animate-child
         >
           <div class="space-y-2">
@@ -154,7 +154,7 @@
             <p>
               Cultivamos reflexão crítica, mas também rituais de cuidado e alegria. Entendemos que a transformação acontece quando teoria e prática se encontram, e quando a ciência dialoga com corpo, cultura e território.
             </p>
-            <p class="mb-2">
+            <p class="mb-2 hidden sm:block">
               Convidamos você a experimentar novos arranjos de convivência, consumo e imaginação, honrando as histórias que nos precedem e abrindo espaço para futuros possíveis.
             </p>
           </div>
@@ -305,7 +305,7 @@
         const revealElements = (element) => {
           element.classList.add('opacity-100', 'translate-y-0');
           element.classList.remove('opacity-0', 'translate-y-8');
-          const children = element.querySelectorAll('[data-animate-child]');
+          const children = Array.from(element.querySelectorAll('[data-animate-child]'));
           children.forEach((child, index) => {
             child.style.transitionDelay = `${(index + 1) * 120}ms`;
             child.classList.add('opacity-100', 'translate-y-0', 'scale-100');
@@ -313,17 +313,30 @@
           });
         };
 
+        const hideElements = (element) => {
+          element.classList.remove('opacity-100', 'translate-y-0');
+          element.classList.add('opacity-0', 'translate-y-8');
+          const children = Array.from(element.querySelectorAll('[data-animate-child]'));
+          const total = children.length;
+          children.forEach((child, index) => {
+            child.style.transitionDelay = `${(total - index) * 80}ms`;
+            child.classList.remove('opacity-100', 'translate-y-0', 'scale-100');
+            child.classList.add('opacity-0', 'translate-y-6', 'scale-95');
+          });
+        };
+
         if ('IntersectionObserver' in window) {
           const observer = new IntersectionObserver(
-            (entries, obs) => {
+            (entries) => {
               entries.forEach((entry) => {
                 if (entry.isIntersecting) {
                   revealElements(entry.target);
-                  obs.unobserve(entry.target);
+                } else {
+                  hideElements(entry.target);
                 }
               });
             },
-            { threshold: 0.2 }
+            { threshold: 0.35, rootMargin: '0px 0px -10% 0px' }
           );
 
           animateSections.forEach((section) => observer.observe(section));


### PR DESCRIPTION
## Summary
- aumenta a transparência da caixa do manifesto para destacar o fundo
- suaviza a animação de entrada e adiciona reversão quando a seção sai da tela
- reduz o texto exibido no manifesto em telas móveis para dois parágrafos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cf29c41883289b995292d77936db