### PR TITLE
Aumenta tamanho dos cards de conteúdos em destaque

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,7 +441,7 @@
         items.forEach((item) => {
           const card = document.createElement('article');
           card.className =
-            'group flex h-[420px] min-w-[85%] flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg snap-center md:min-w-0 md:h-[480px]';
+            'group flex h-[480px] min-w-[90%] flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg snap-center md:min-w-0 md:h-[540px]';
 
           const figure = document.createElement('div');
           figure.className = 'relative flex-[0.7] overflow-hidden bg-slate-200 md:flex-[0.65]';


### PR DESCRIPTION
## Resumo
- aumenta a altura dos cards da seção de conteúdos em destaque para ampliar imagem e texto de forma proporcional
- expande a largura mínima dos cards no carrossel móvel para destacar mais cada conteúdo

## Testes
- não foram executados testes (não aplicável)

------
https://chatgpt.com/codex/tasks/task_e_68d2aff9450c8328b9cbd0053a09e7d5