### PR TITLE
Ajusta enquadramento das imagens dos cards de conteúdos

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@
             img.alt = item.alt || item.titulo || 'Conteúdo em destaque';
             img.loading = 'lazy';
             img.decoding = 'async';
-            img.className = 'h-full w-full object-cover object-center';
+            img.className = 'h-full w-full object-cover object-top';
             figure.appendChild(img);
           } else {
             figure.innerHTML = '<span class="sr-only">Imagem ilustrativa do conteúdo</span>';


### PR DESCRIPTION
## Summary
- prioriza o topo das imagens nos cards de conteúdos em destaque ao usar `object-position: top`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2b3a7e1848328b7dd499b6959d6b3