### PR TITLE
Add gradient transition between featured and experiment sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,8 @@
       </div>
     </section>
 
+    <div class="h-24 bg-gradient-to-b from-white to-muted" aria-hidden="true"></div>
+
     <section class="mx-auto max-w-5xl px-4 py-16 lg:px-8" aria-labelledby="reflexao-heading">
       <div class="rounded-3xl bg-background px-8 py-12 text-white shadow-lg">
         <p class="font-semibold uppercase tracking-[0.3em] text-accent">Experimentar</p>


### PR DESCRIPTION
## Summary
- add a vertical gradient separator between the featured content and experiment sections on the home page
- use existing brand colors to create a subtle transition that preserves responsiveness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2b97cc86083289ebc998bc30ee466