### PR TITLE
Refine Experimentar section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,10 +210,13 @@
     <div class="h-24 bg-gradient-to-b from-white to-muted" aria-hidden="true"></div>
 
     <section class="mx-auto max-w-5xl px-4 py-16 lg:px-8" aria-labelledby="reflexao-heading">
-      <div class="rounded-3xl bg-background px-8 py-12 text-white shadow-lg">
-        <p class="font-semibold uppercase tracking-[0.3em] text-accent">Experimentar</p>
-        <h2 id="reflexao-heading" class="mt-2 font-display text-4xl uppercase">O que seu corpo ancestral faria diante do mundo moderno?</h2>
-        <p class="mt-4 text-white/80">Escolha uma resposta para desbloquear uma reflexão instantânea.</p>
+      <div class="text-center">
+        <p class="font-semibold uppercase tracking-[0.35em] text-xl text-[#449f60] sm:text-2xl">Experimentar</p>
+        <h2 id="reflexao-heading" class="mt-4 font-display text-3xl font-bold text-background sm:text-4xl">O que seu corpo ancestral faria diante do mundo moderno?</h2>
+      </div>
+      <div class="mt-10 rounded-3xl bg-background px-8 py-12 text-white shadow-lg">
+        <p class="text-white/80">Escolha uma resposta para desbloquear uma reflexão instantânea.</p>
+        <p class="mt-2 text-base font-medium text-white">Suas escolhas revelam muito mais do que você imagina — clique e descubra.</p>
         <div class="mt-8 flex flex-col gap-4 sm:flex-row" role="group" aria-label="Opções de reflexão">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- move Experimentar headings outside the quiz container and increase their prominence
- update the quiz card to keep the original prompt and add a follow-up interaction message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2bd63388c8328ac545e7d03748bae