### PR TITLE
Adjust Experimentar section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,11 +210,11 @@
     <div class="h-24 bg-gradient-to-b from-white to-muted" aria-hidden="true"></div>
 
     <section class="mx-auto max-w-5xl px-4 py-12 sm:py-16 lg:px-8" aria-labelledby="reflexao-heading">
-      <div class="text-center">
+      <div class="text-left">
         <p class="font-semibold uppercase tracking-[0.35em] text-xl text-[#449f60] sm:text-2xl">Experimentar</p>
-        <h2 id="reflexao-heading" class="mt-4 font-display text-3xl font-semibold text-background sm:text-4xl">O que seu corpo ancestral faria diante do mundo moderno?</h2>
+        <h2 id="reflexao-heading" class="mt-4 font-display text-3xl font-normal text-background sm:text-4xl">O que seu corpo ancestral faria diante do mundo moderno?</h2>
       </div>
-      <div class="mt-10 mx-auto max-w-3xl rounded-3xl bg-background px-6 py-14 text-white shadow-lg sm:px-8 lg:py-16">
+      <div class="mt-10 rounded-3xl bg-background px-8 py-12 text-white shadow-lg">
         <p class="text-white/80">Escolha uma resposta para desbloquear uma reflexão instantânea.</p>
         <p class="mt-2 text-base font-medium text-white">Suas escolhas revelam muito mais do que você imagina — clique e descubra.</p>
         <div class="mt-8 flex flex-col gap-4 sm:flex-row" role="group" aria-label="Opções de reflexão">


### PR DESCRIPTION
## Summary
- lighten the Experimentar subtitle weight to match surrounding typography
- left-align the Experimentar heading block and restore the quiz container to its previous width and padding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2c2a72e7483288c12b222688f8667