### PR TITLE
Configure newsletter form for MailerLite integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,17 +102,18 @@
           <p class="mt-2 text-sm text-white/75">
             Quinzenalmente na sua caixa de e-mail. Textos e reflexões para quebrar seus paradigmas ;)
           </p>
+          <!-- TODO: substituir SEU_FORM_ID pelo ID real do formulário da MailerLite -->
           <form
             class="mt-4 space-y-3"
             aria-label="Formulário de inscrição na newsletter"
-            action="https://app.mailerlite.com/webforms/submit/placeholder"
+            action="https://assets.mailerlite.com/webforms/submit/SEU_FORM_ID"
             method="post"
             target="_blank"
           >
             <label class="sr-only" for="hero-newsletter-email">Email</label>
             <input
               id="hero-newsletter-email"
-              name="fields[email]"
+              name="email"
               type="email"
               class="w-full rounded-full border border-white/30 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/60 focus-visible"
               placeholder="nome@email.com"


### PR DESCRIPTION
## Summary
- point the hero newsletter form to the MailerLite subscription endpoint and note the placeholder form ID
- update the email input name to match MailerLite requirements while preserving existing styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7208bda3c8328ac0f430b898db91d