### PR TITLE
Reorganize layout da página sobre

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -66,41 +66,23 @@
   </header>
 
   <main id="conteudo-principal">
-    <!-- INÍCIO BLOCO HERO SOBRE -->
+    <!-- INÍCIO BLOCO EQUIPE (HEADING PRINCIPAL) -->
     <section class="relative overflow-hidden bg-background text-foreground">
       <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Formas abstratas representando colaboração" class="absolute inset-0 h-full w-full" />
         <div class="relative mx-auto flex max-w-6xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
-          <p class="font-semibold uppercase tracking-[0.3em] text-accent">Sobre nós</p>
-          <h1 class="font-display text-5xl uppercase leading-tight">Laboratório de futuros regenerativos</h1>
-          <p class="max-w-3xl text-lg text-foreground/80">Somos estrategistas, cientistas, educadores e artistas experimentando novas maneiras de viver em sintonia com a natureza.</p>
-        </div>
-      </div>
-    </section>
-    <!-- FIM BLOCO HERO SOBRE -->
-
-    <!-- INÍCIO BLOCO HISTÓRIA -->
-    <section class="mx-auto max-w-5xl px-4 py-16 lg:px-8">
-      <div class="section-card section-card--dark space-y-6 p-10">
-        <h2 class="font-display text-3xl uppercase">Nossa jornada</h2>
-        <!-- INÍCIO BLOCO HISTÓRIA -->
-        <p class="text-sm text-foreground/80">Nasceu em 2018 a partir de encontros espontâneos em espaços independentes. A cada roda, percebíamos o desejo coletivo de integrar ciência, arte e espiritualidade de forma prática. Transformamos essas conversas em uma plataforma que acolhe projetos colaborativos e prototipa iniciativas de impacto social.</p>
-        <!-- FIM BLOCO HISTÓRIA -->
-      </div>
-    </section>
-    <!-- FIM BLOCO HISTÓRIA -->
-
-    <!-- INÍCIO BLOCO EQUIPE -->
-    <section class="mx-auto max-w-6xl px-4 pb-16 lg:px-8">
-      <div class="mb-10 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Equipe</p>
-          <h2 class="font-display text-4xl uppercase">Quem cuida do ;paradigma</h2>
+          <h1 class="font-display text-5xl uppercase leading-tight">Quem cuida do ;paradigma</h1>
+          <p class="max-w-3xl text-lg text-foreground/80">Formamos um coletivo multidisciplinar. Cada pessoa carrega repertórios distintos que se somam em experiências imersivas.</p>
         </div>
-        <p class="max-w-xl text-lg text-slate-600">Formamos um coletivo multidisciplinar. Cada pessoa carrega repertórios distintos que se somam em experiências imersivas.</p>
       </div>
+    </section>
+    <!-- FIM BLOCO EQUIPE (HEADING PRINCIPAL) -->
+
+    <!-- INÍCIO BLOCO CARDS EQUIPE -->
+    <section class="mx-auto max-w-6xl px-4 pb-16 lg:px-8">
+      <h2 class="sr-only">Integrantes do ;paradigma</h2>
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        <!-- INÍCIO BLOCO CARDS EQUIPE -->
         <article class="section-card p-6">
           <h3 class="font-display text-2xl uppercase text-background">Lia Monte</h3>
           <p class="mt-2 text-sm text-slate-600">Bióloga evolutiva e diretora de pesquisa. Conecta descobertas científicas a aplicações cotidianas.</p>
@@ -113,20 +95,20 @@
           <h3 class="font-display text-2xl uppercase">Amaranta Reis</h3>
           <p class="mt-2 text-sm text-foreground/80">Artista e facilitadora de experiências somáticas. Pesquisa interseções entre corpo e tecnologia.</p>
         </article>
-        <!-- FIM BLOCO CARDS EQUIPE -->
       </div>
     </section>
-    <!-- FIM BLOCO EQUIPE -->
+    <!-- FIM BLOCO CARDS EQUIPE -->
 
-    <!-- INÍCIO BLOCO CHAMADA CONTATO -->
-    <section class="mx-auto max-w-4xl px-4 pb-20 lg:px-8">
-      <div class="section-card section-card--dark p-10 text-center">
-        <h2 class="font-display text-3xl uppercase">Quer cocriar com a gente?</h2>
-        <p class="mt-4 text-lg text-foreground/80">Abrimos agendas trimestrais para novos projetos, residências artísticas e programas corporativos.</p>
-        <a href="/contato.html" class="focus-visible mt-8 inline-flex items-center justify-center rounded-full bg-accent px-8 py-3 font-semibold text-background transition hover:bg-foreground hover:text-background">Fale com o coletivo</a>
+    <!-- INÍCIO BLOCO HISTÓRIA -->
+    <section class="mx-auto max-w-5xl px-4 pb-20 lg:px-8">
+      <div class="section-card section-card--dark space-y-6 p-10">
+        <h2 class="font-display text-3xl uppercase">Nossa jornada</h2>
+        <!-- INÍCIO BLOCO HISTÓRIA -->
+        <p class="text-sm text-foreground/80">Nasceu em 2018 a partir de encontros espontâneos em espaços independentes. A cada roda, percebíamos o desejo coletivo de integrar ciência, arte e espiritualidade de forma prática. Transformamos essas conversas em uma plataforma que acolhe projetos colaborativos e prototipa iniciativas de impacto social.</p>
+        <!-- FIM BLOCO HISTÓRIA -->
       </div>
     </section>
-    <!-- FIM BLOCO CHAMADA CONTATO -->
+    <!-- FIM BLOCO HISTÓRIA -->
   </main>
 
   <footer class="bg-background py-10 text-foreground">


### PR DESCRIPTION
## Summary
- reposiciona o bloco da equipe para o topo da página sobre como heading principal
- mantém os cards da equipe após o destaque principal e reposiciona a seção "Nossa jornada" como subheading secundária
- remove a chamada "Quer cocriar com a gente?" conforme solicitado

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87b8bc0a4832881960785aae57347