### PR TITLE
Connect contact form to email delivery

### DIFF
--- a/contato.html
+++ b/contato.html
@@ -83,7 +83,8 @@
     <section class="mx-auto max-w-4xl px-4 py-16 lg:px-8">
       <div class="section-card p-10">
         <h2 class="font-display text-3xl uppercase text-background">Envie uma mensagem</h2>
-        <form class="mt-8 space-y-6" aria-label="Formulário de contato">
+        <form class="mt-8 space-y-6" aria-label="Formulário de contato" action="send_mail.php" method="post">
+          <div id="form-status-message" class="hidden rounded-lg border px-4 py-3 text-sm font-medium" role="alert"></div>
           <div>
             <label class="block text-sm font-semibold text-slate-600" for="nome">Nome</label>
             <input id="nome" name="nome" type="text" required class="focus-visible mt-2 w-full rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm" placeholder="Seu nome" />
@@ -139,6 +140,34 @@
     const anoFooter = document.getElementById('ano-footer');
     if (anoFooter) {
       anoFooter.textContent = new Date().getFullYear().toString();
+    }
+
+    const formStatusMessage = document.getElementById('form-status-message');
+    if (formStatusMessage) {
+      const params = new URLSearchParams(window.location.search);
+      const status = params.get('status');
+      const message = params.get('message');
+
+      if (status && message) {
+        const successClasses = ['border-emerald-300', 'bg-emerald-50', 'text-emerald-700'];
+        const errorClasses = ['border-red-300', 'bg-red-50', 'text-red-700'];
+
+        formStatusMessage.textContent = message;
+        formStatusMessage.classList.remove('hidden');
+        formStatusMessage.classList.remove(...successClasses, ...errorClasses);
+
+        if (status === 'success') {
+          formStatusMessage.classList.add(...successClasses);
+        } else {
+          formStatusMessage.classList.add(...errorClasses);
+        }
+
+        params.delete('status');
+        params.delete('message');
+        const remaining = params.toString();
+        const newUrl = remaining ? `${window.location.pathname}?${remaining}` : window.location.pathname;
+        window.history.replaceState({}, '', newUrl);
+      }
     }
   </script>
 </body>

--- a/send_mail.php
+++ b/send_mail.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+
+require __DIR__ . '/vendor/autoload.php';
+
+/**
+ * Redirect helper with status and message.
+ */
+function redirect_with_status(string $status, string $message): void
+{
+    $params = [
+        'status' => $status,
+        'message' => $message,
+    ];
+
+    header('Location: contato.html?' . http_build_query($params));
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    redirect_with_status('error', 'Método de envio inválido.');
+}
+
+$nome = isset($_POST['nome']) ? trim((string) $_POST['nome']) : '';
+$email = isset($_POST['email']) ? trim((string) $_POST['email']) : '';
+$assunto = isset($_POST['assunto']) ? trim((string) $_POST['assunto']) : '';
+$mensagem = isset($_POST['mensagem']) ? trim((string) $_POST['mensagem']) : '';
+
+$nome = preg_replace('/[\r\n]+/', ' ', $nome);
+$assunto = preg_replace('/[\r\n]+/', ' ', $assunto);
+$email = preg_replace('/[\r\n]+/', '', $email);
+
+if ($nome === '' || $email === '' || $mensagem === '') {
+    redirect_with_status('error', 'Preencha todos os campos obrigatórios.');
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    redirect_with_status('error', 'Informe um email válido.');
+}
+
+$assuntoEmail = $assunto !== '' ? $assunto : 'Nova mensagem pelo site ;paradigma';
+
+$bodyHtml = '<h2>Novo contato pelo site ;paradigma</h2>';
+$bodyHtml .= '<p><strong>Nome:</strong> ' . htmlspecialchars($nome, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
+$bodyHtml .= '<p><strong>Email:</strong> ' . htmlspecialchars($email, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
+$bodyHtml .= '<p><strong>Assunto:</strong> ' . htmlspecialchars($assuntoEmail, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</p>';
+$bodyHtml .= '<p><strong>Mensagem:</strong></p>';
+$bodyHtml .= '<p>' . nl2br(htmlspecialchars($mensagem, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')) . '</p>';
+
+$bodyText = "Novo contato pelo site ;paradigma\n";
+$bodyText .= 'Nome: ' . $nome . "\n";
+$bodyText .= 'Email: ' . $email . "\n";
+$bodyText .= 'Assunto: ' . $assuntoEmail . "\n\n";
+$bodyText .= "Mensagem:\n" . $mensagem . "\n";
+
+try {
+    $mail = new PHPMailer(true);
+    $mail->CharSet = 'UTF-8';
+    $mail->isMail();
+    $mail->setFrom($email, $nome);
+    $mail->addAddress('newsletter@siteparadigma.com.br', 'Contato ;paradigma');
+    $mail->addReplyTo($email, $nome);
+    $mail->Subject = $assuntoEmail;
+    $mail->isHTML(true);
+    $mail->Body = $bodyHtml;
+    $mail->AltBody = $bodyText;
+
+    $mail->send();
+} catch (Exception $exception) {
+    redirect_with_status('error', 'Não foi possível enviar sua mensagem. Tente novamente em instantes.');
+} catch (\Throwable $throwable) {
+    redirect_with_status('error', 'Ocorreu um erro inesperado ao enviar a mensagem.');
+}
+
+redirect_with_status('success', 'Mensagem enviada com sucesso! Em breve entraremos em contato.');

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -1,0 +1,14 @@
+<?php
+spl_autoload_register(function (string $class): void {
+    $prefix = 'PHPMailer\\PHPMailer\\';
+    $baseDir = __DIR__ . '/phpmailer/phpmailer/src/';
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+    $relativeClass = substr($class, $len);
+    $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+    if (is_file($file)) {
+        require $file;
+    }
+});

--- a/vendor/phpmailer/phpmailer/src/Exception.php
+++ b/vendor/phpmailer/phpmailer/src/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PHPMailer\PHPMailer;
+
+class Exception extends \Exception
+{
+}

--- a/vendor/phpmailer/phpmailer/src/PHPMailer.php
+++ b/vendor/phpmailer/phpmailer/src/PHPMailer.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace PHPMailer\PHPMailer;
+
+class PHPMailer
+{
+    public string $CharSet = 'UTF-8';
+    public string $Encoding = '8bit';
+    public string $Subject = '';
+    public string $Body = '';
+    public string $AltBody = '';
+    public string $ErrorInfo = '';
+
+    protected string $fromEmail = '';
+    protected string $fromName = '';
+    protected array $addresses = [];
+    protected array $replyTo = [];
+    protected bool $isHTML = false;
+    protected bool $exceptions = false;
+
+    public function __construct(bool $exceptions = false)
+    {
+        $this->exceptions = $exceptions;
+    }
+
+    public function isMail(): void
+    {
+        // Default mail transport; provided for interface compatibility.
+    }
+
+    public function isHTML(bool $isHtml = true): void
+    {
+        $this->isHTML = $isHtml;
+    }
+
+    public function setFrom(string $address, string $name = ''): bool
+    {
+        if (!$this->isValidEmail($address)) {
+            return $this->setError('Endereço de email do remetente inválido.');
+        }
+
+        $this->fromEmail = $address;
+        $this->fromName = $name;
+
+        return true;
+    }
+
+    public function addAddress(string $address, string $name = ''): bool
+    {
+        if (!$this->isValidEmail($address)) {
+            return $this->setError('Endereço de email do destinatário inválido.');
+        }
+
+        $this->addresses[] = [
+            'email' => $address,
+            'name' => $name,
+        ];
+
+        return true;
+    }
+
+    public function addReplyTo(string $address, string $name = ''): bool
+    {
+        if (!$this->isValidEmail($address)) {
+            return $this->setError('Endereço de email de resposta inválido.');
+        }
+
+        $this->replyTo[] = [
+            'email' => $address,
+            'name' => $name,
+        ];
+
+        return true;
+    }
+
+    public function send(): bool
+    {
+        if ($this->fromEmail === '') {
+            return $this->setError('Remetente não definido.');
+        }
+
+        if (empty($this->addresses)) {
+            return $this->setError('Nenhum destinatário informado.');
+        }
+
+        $to = array_map(fn ($address) => $this->formatAddress($address['email'], $address['name']), $this->addresses);
+
+        $headers = [];
+        $headers[] = $this->headerLine('From', $this->formatAddress($this->fromEmail, $this->fromName));
+
+        if (!empty($this->replyTo)) {
+            $replyTo = array_map(fn ($address) => $this->formatAddress($address['email'], $address['name']), $this->replyTo);
+            $headers[] = $this->headerLine('Reply-To', implode(', ', $replyTo));
+        }
+
+        $headers[] = $this->headerLine('MIME-Version', '1.0');
+        $headers[] = $this->headerLine(
+            'Content-Type',
+            ($this->isHTML ? 'text/html' : 'text/plain') . '; charset=' . $this->CharSet
+        );
+        $headers[] = $this->headerLine('Content-Transfer-Encoding', $this->Encoding);
+
+        $subject = $this->encodeHeader($this->Subject);
+        $body = $this->isHTML ? $this->Body : ($this->AltBody !== '' ? $this->AltBody : $this->Body);
+
+        $result = mail(implode(', ', $to), $subject, $body, implode("\r\n", $headers));
+
+        if ($result === false) {
+            return $this->setError('Falha ao enviar o email.');
+        }
+
+        return true;
+    }
+
+    protected function headerLine(string $name, string $value): string
+    {
+        return sprintf('%s: %s', $name, $value);
+    }
+
+    protected function formatAddress(string $email, string $name = ''): string
+    {
+        $cleanName = trim($name);
+        if ($cleanName === '') {
+            return $email;
+        }
+
+        return sprintf('%s <%s>', $this->encodeHeader($cleanName), $email);
+    }
+
+    protected function encodeHeader(string $value): string
+    {
+        $needsEncoding = preg_match('/[^\x20-\x7E]/', $value) === 1;
+
+        if ($needsEncoding) {
+            return '=?' . $this->CharSet . '?B?' . base64_encode($value) . '?=';
+        }
+
+        return $value;
+    }
+
+    protected function isValidEmail(string $address): bool
+    {
+        return (bool) filter_var($address, FILTER_VALIDATE_EMAIL);
+    }
+
+    protected function setError(string $message): bool
+    {
+        $this->ErrorInfo = $message;
+
+        if ($this->exceptions) {
+            throw new Exception($message);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a PHP mail handler that sends contact form submissions to newsletter@siteparadigma.com.br with the visitor as the sender
- wire the existing contact form to the new endpoint and surface success or error messaging inside the form
- bundle a lightweight autoloader and PHPMailer implementation so the handler can run without external dependencies

## Testing
- php -l send_mail.php

------
https://chatgpt.com/codex/tasks/task_e_68d887293f7883289bc43264489f8e98