### PR TITLE
Improve contact form SMTP configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config/mail.php

--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ A página inicial foi reorganizada em blocos independentes. Os textos podem ser 
 ## Visualizar localmente
 
 Abra qualquer arquivo `.html` diretamente no navegador. Não há build ou servidor necessários.
+
+## Configurar o envio do formulário de contato
+
+O formulário em `contato.html` usa `send_mail.php`, que depende das credenciais SMTP da Hostinger para disparar as mensagens a partir do endereço `newsletter@siteparadigma.com.br`.
+
+1. No painel da Hostinger, copie o usuário (email completo) e a senha da caixa postal ou gere uma senha de aplicativo.
+2. Em produção, defina as variáveis de ambiente `HOSTINGER_SMTP_USER` e `HOSTINGER_SMTP_PASSWORD` com esses valores.
+3. Caso não seja possível trabalhar com variáveis de ambiente, crie um arquivo `config/mail.php` (o repositório já contém `config/mail.example.php` como referência) retornando um array com as chaves `username` e `password`.
+
+Sem uma dessas configurações o script exibe o aviso “Configuração de email ausente” e o envio não é realizado.

--- a/config/mail.example.php
+++ b/config/mail.example.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    // Usuário da caixa postal na Hostinger (geralmente o email completo)
+    'username' => 'newsletter@siteparadigma.com.br',
+
+    // Senha da caixa postal ou token de app gerado no painel da Hostinger.
+    // Substitua pelo valor real e salve uma cópia como config/mail.php (não versionada).
+    'password' => 'COLOQUE_AQUI_A_SENHA_DA_HOSTINGER',
+];

--- a/send_mail.php
+++ b/send_mail.php
@@ -60,11 +60,30 @@ $bodyText .= "Mensagem:\n" . $mensagem . "\n";
 /** @var PHPMailer|null $mail */
 $mail = null;
 
-$smtpUser = getenv('HOSTINGER_SMTP_USER') ?: 'newsletter@siteparadigma.com.br';
-$smtpPassword = getenv('HOSTINGER_SMTP_PASSWORD');
+$configPath = __DIR__ . '/config/mail.php';
+$mailConfig = [];
 
+if (is_readable($configPath)) {
+    $loadedConfig = include $configPath;
+    if (is_array($loadedConfig)) {
+        $mailConfig = $loadedConfig;
+    }
+}
+
+$smtpUser = getenv('HOSTINGER_SMTP_USER');
+if ($smtpUser === false || trim((string) $smtpUser) === '') {
+    $smtpUser = $mailConfig['username'] ?? 'newsletter@siteparadigma.com.br';
+}
+$smtpUser = trim((string) $smtpUser);
+
+$smtpPassword = getenv('HOSTINGER_SMTP_PASSWORD');
 if ($smtpPassword === false || trim((string) $smtpPassword) === '') {
-    redirect_with_status('error', 'Configuração de email ausente.');
+    $smtpPassword = $mailConfig['password'] ?? '';
+}
+$smtpPassword = trim((string) $smtpPassword);
+
+if ($smtpPassword === '') {
+    redirect_with_status('error', 'Configuração de email ausente. Defina as variáveis de ambiente ou o arquivo config/mail.php.');
 }
 
 try {


### PR DESCRIPTION
## Summary
- allow send_mail.php to read Hostinger SMTP credentials from environment variables or a non-versioned config/mail.php fallback
- add a config/mail.example.php template and ignore the real config file to keep secrets out of git
- document the setup steps for the contact form credentials in the README

## Testing
- php -l send_mail.php
- php -l config/mail.example.php

------
https://chatgpt.com/codex/tasks/task_e_68d95a05d984832897dcd72ce0e6b3af