### PR TITLE
Ajusta layout mobile da página de contato

### DIFF
--- a/contato.html
+++ b/contato.html
@@ -102,46 +102,46 @@
     <section class="relative overflow-hidden bg-background text-foreground">
       <div class="hero-overlay relative w-full">
         <img src="/assets/img/hero-overlay.svg" alt="Luzes verdes representando conexões" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex max-w-4xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
+        <div class="relative mx-auto flex max-w-4xl flex-col justify-center gap-4 px-4 py-16 sm:py-24 lg:px-8 lg:py-20">
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Contato</p>
-          <h1 class="font-display text-5xl uppercase leading-tight">Ative uma conversa</h1>
-          <p class="max-w-2xl text-lg text-foreground/80">Queremos colaborar com pessoas e organizações que buscam regenerar ecossistemas humanos.</p>
+          <h1 class="font-display text-4xl uppercase leading-tight sm:text-5xl">Ative uma conversa</h1>
+          <p class="max-w-2xl text-base text-foreground/80 sm:text-lg">Queremos colaborar com pessoas e organizações que buscam regenerar ecossistemas humanos.</p>
         </div>
       </div>
     </section>
     <!-- FIM BLOCO HERO CONTATO -->
 
     <!-- INÍCIO BLOCO MENSAGEM -->
-    <section class="relative mx-auto max-w-4xl px-4 py-16 lg:px-8">
-      <div class="relative overflow-hidden rounded-3xl bg-background p-10 text-foreground shadow-lg">
+    <section class="relative mx-auto max-w-4xl px-4 py-12 sm:py-16 lg:px-8">
+      <div class="relative overflow-hidden rounded-3xl bg-background p-6 text-foreground shadow-lg sm:p-8 lg:p-10">
         <span class="floating-orb floating-delay-1 pointer-events-none absolute -left-12 top-4 h-36 w-36 rounded-full bg-accent/20 blur-2xl"></span>
         <span class="floating-orb floating-delay-2 pointer-events-none absolute -right-10 bottom-0 h-32 w-32 rounded-full bg-foreground/10 blur-2xl"></span>
         <div class="floating-orb pointer-events-none absolute left-1/2 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent/10 blur-3xl"></div>
 
-        <div class="relative z-10 flex flex-col gap-6">
-          <div class="inline-flex items-center gap-3 self-start rounded-full border border-foreground/20 bg-foreground/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-foreground/70">
+        <div class="relative z-10 flex flex-col gap-5 sm:gap-6">
+          <div class="inline-flex items-center gap-3 self-start rounded-full border border-foreground/20 bg-foreground/5 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.3em] text-foreground/70 sm:px-4 sm:text-xs">
             <span aria-hidden="true">✶</span>
             <span>Canal direto</span>
           </div>
-          <h2 class="font-display text-3xl uppercase">Vamos conversar por e-mail</h2>
-          <p class="max-w-2xl text-base text-foreground/80">
+          <h2 class="font-display text-2xl uppercase sm:text-3xl">Vamos conversar por e-mail</h2>
+          <p class="max-w-2xl text-sm text-foreground/80 sm:text-base">
             Para entrar em contato com a gente baste enviar um e-mail para:
-            <button type="button" class="focus-visible ml-2 inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-4 py-2 text-sm font-semibold text-accent transition hover:bg-accent/20" data-reveal-button aria-expanded="false" aria-controls="contato-email">
+            <button type="button" class="focus-visible ml-2 inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-3 py-2 text-xs font-semibold text-accent transition hover:bg-accent/20 sm:px-4 sm:text-sm" data-reveal-button aria-expanded="false" aria-controls="contato-email">
               <svg class="h-4 w-4 transition-transform" data-reveal-icon xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
               </svg>
               <span data-reveal-label>Mostrar e-mail</span>
             </button>
           </p>
-          <div id="contato-email" class="relative max-w-xl overflow-hidden rounded-2xl border border-foreground/10 bg-foreground/5 px-8 py-6 opacity-0 transition-all duration-500 ease-out -translate-y-3" data-email-panel hidden>
+          <div id="contato-email" class="relative max-w-xl overflow-hidden rounded-2xl border border-foreground/10 bg-foreground/5 px-5 py-5 opacity-0 transition-all duration-500 ease-out -translate-y-3 sm:px-6 sm:py-6 lg:px-8" data-email-panel hidden>
             <div class="absolute inset-0 bg-gradient-to-r from-accent/20 via-transparent to-foreground/10 opacity-0 transition-opacity duration-700" data-email-glow></div>
             <p class="text-sm uppercase tracking-[0.4em] text-foreground/50">Endereço</p>
             <div class="mt-3">
               <div class="relative flex min-h-[3.5rem] w-full items-center">
-                <span class="font-display text-2xl uppercase text-foreground whitespace-nowrap transition duration-500" data-email-text>newsletter@siteparadigma.com.br</span>
+                <span class="font-display text-xl uppercase text-foreground whitespace-nowrap transition duration-500 sm:text-2xl" data-email-text>newsletter@siteparadigma.com.br</span>
               </div>
             </div>
-            <button type="button" class="focus-visible mt-6 inline-flex items-center gap-2 rounded-full bg-accent px-6 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-background transition hover:bg-foreground" data-copy-email data-default-label="Copiar endereço">
+            <button type="button" class="focus-visible mt-5 inline-flex items-center gap-2 rounded-full bg-accent px-5 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-background transition hover:bg-foreground sm:mt-6 sm:px-6 sm:text-sm" data-copy-email data-default-label="Copiar endereço">
               <span data-copy-label>Copiar endereço</span>
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Ajusta espaçamentos e tipografia do hero de contato para melhorar a leitura em telas menores
- Redimensiona o cartão e seus elementos para caber melhor em dispositivos mobile

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68d96ce336c88328a02af2a3d0cba1f3