### PR TITLE
Add quiz subtitle between featured and experiment sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,6 +282,12 @@
       </div>
     </section>
 
+    <div class="mx-auto max-w-6xl px-4 py-16 text-center lg:px-8">
+      <h2 class="font-display text-4xl uppercase text-background">
+        Complete esse quiz e descubra suas capacidades evolutivas.
+      </h2>
+    </div>
+
     <div class="h-24 bg-gradient-to-b from-white to-muted" aria-hidden="true"></div>
 
     <section class="mx-auto max-w-5xl px-4 pb-12 pt-8 sm:py-16 lg:px-8" aria-labelledby="reflexao-heading">


### PR DESCRIPTION
## Summary
- add a quiz call-to-action subtitle between the featured content and experiment sections on the home page
- reuse existing subtitle styling with centered layout and consistent spacing for mobile and desktop

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d98a9c61908328ac07546c49e8095b