### PR TITLE
Ajustes de layout mobile e transição entre seções

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
         <img src="/assets/img/hero-overlay.svg" alt="Texturas orgânicas e formas abstratas" class="h-full w-full object-cover" />
         <div class="absolute inset-0 bg-black/75 mix-blend-multiply" aria-hidden="true"></div>
       </div>
-      <div class="relative mx-auto flex max-w-6xl flex-col gap-10 px-4 py-24 sm:py-32 lg:flex-row lg:items-center lg:px-8">
+      <div class="relative mx-auto flex max-w-6xl flex-col gap-10 px-4 pt-16 pb-24 sm:py-32 lg:flex-row lg:items-center lg:px-8">
         <div class="max-w-2xl space-y-6">
           <p class="font-semibold uppercase tracking-[0.35em] text-accent">Biologia evolutiva na prática</p>
           <h1 id="hero-heading" class="font-display text-5xl uppercase leading-tight text-white sm:text-6xl lg:text-7xl">
@@ -242,7 +242,27 @@
       </div>
     </section>
 
-    <section id="conteudos-destaque" class="bg-white py-16" aria-labelledby="conteudos-heading">
+    <div class="relative -mt-6 h-16 overflow-hidden" aria-hidden="true">
+      <svg
+        class="absolute inset-0 h-full w-full"
+        viewBox="0 0 1440 160"
+        xmlns="http://www.w3.org/2000/svg"
+        preserveAspectRatio="none"
+      >
+        <defs>
+          <linearGradient id="manifesto-wave" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stop-color="rgba(9, 9, 11, 0.4)" />
+            <stop offset="100%" stop-color="#ffffff" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M0 80L60 74.7C120 69 240 58 360 58.7C480 59 600 74 720 80C840 86 960 80 1080 74.7C1200 69 1320 64 1380 61.3L1440 58V160H1380C1320 160 1200 160 1080 160C960 160 840 160 720 160C600 160 480 160 360 160C240 160 120 160 60 160H0Z"
+          fill="url(#manifesto-wave)"
+        />
+      </svg>
+    </div>
+
+    <section id="conteudos-destaque" class="bg-white pt-16 pb-12" aria-labelledby="conteudos-heading">
       <div class="mx-auto max-w-6xl px-4 lg:px-8">
         <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div>
@@ -290,20 +310,20 @@
 
     <div class="h-24 bg-gradient-to-b from-white to-muted" aria-hidden="true"></div>
 
-    <section class="mx-auto max-w-5xl px-4 pb-12 pt-8 sm:py-16 lg:px-8" aria-labelledby="reflexao-heading">
+    <section class="mx-auto max-w-5xl px-4 pb-12 pt-8 sm:pt-16 sm:pb-12 lg:px-8" aria-labelledby="reflexao-heading">
       <div class="rounded-3xl bg-background px-6 py-10 text-white shadow-lg sm:px-8 sm:py-12">
-        <div class="text-left">
+        <div class="text-center">
           <p class="font-semibold uppercase tracking-[0.35em] text-xl text-[#449f60] sm:text-2xl">Experimentar</p>
           <h2 id="reflexao-heading" class="mt-4 font-display text-3xl font-normal text-white sm:text-4xl">O que seu corpo ancestral faria diante do mundo moderno?</h2>
         </div>
-        <p class="mt-6 text-white/80">Responda às perguntas para revelar o instinto que guiaria sua evolução.</p>
-        <p class="mt-2 text-base font-medium text-white">Cada escolha soma pontos e monta o seu perfil biológico evolutivo.</p>
+        <p class="mt-6 text-center text-white/80">Responda às perguntas para revelar o instinto que guiaria sua evolução.</p>
+        <p class="mt-2 text-center text-base font-medium text-white">Cada escolha soma pontos e monta o seu perfil biológico evolutivo.</p>
         <div class="mt-8 space-y-6" data-quiz>
           <div class="space-y-4" data-quiz-content>
-            <p class="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
+            <p class="text-center text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
               Pergunta <span data-quiz-progress>1</span> de <span data-quiz-total>5</span>
             </p>
-            <h3 class="font-display text-2xl font-normal text-white sm:text-3xl" data-quiz-question>
+            <h3 class="text-center font-display text-2xl font-normal text-white sm:text-3xl" data-quiz-question>
               O que seu corpo ancestral faria diante do mundo moderno?
             </h3>
             <div class="mt-6 flex flex-col gap-4 sm:grid sm:grid-cols-3" data-quiz-options role="group" aria-label="Opções do quiz"></div>
@@ -313,7 +333,7 @@
             class="focus-visible hidden w-full rounded-full border border-white/40 px-6 py-3 text-center font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10"
             data-quiz-result-button
           >Ver resultado</button>
-          <div class="mt-6 hidden min-h-[4rem] rounded-2xl bg-white/10 p-6 text-left text-sm text-white/90" data-quiz-result aria-live="polite"></div>
+          <div class="mt-6 hidden min-h-[4rem] rounded-2xl bg-white/10 p-6 text-center text-sm text-white/90" data-quiz-result aria-live="polite"></div>
         </div>
       </div>
     </section>
@@ -339,9 +359,6 @@
       </div>
     </section>
 
-    <section class="bg-background py-16 text-center text-white" aria-label="Mensagem final">
-      <p class="mx-auto max-w-3xl px-4 font-display text-4xl uppercase">A ;paradigma existe para unir a crítica à esperança.</p>
-    </section>
   </main>
 
   <footer class="bg-background py-12 text-white" role="contentinfo">


### PR DESCRIPTION
## Summary
- reduz o padding superior do herói para melhorar a experiência em telas móveis
- adiciona uma onda em SVG para suavizar a transição entre as seções Manifesto e Conteúdos em destaque
- centraliza os textos do quiz, ajusta espaçamentos inferiores e remove a frase final do rodapé

## Testing
- no tests were run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68da868161048328b06467f532c2442a