### PR TITLE
Add diagonal transition between manifesto and featured sections

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -43,6 +43,33 @@ header {
   object-fit: cover;
 }
 
+.transition-block {
+  position: relative;
+  width: 100%;
+  margin-top: -3rem;
+  line-height: 0;
+  pointer-events: none;
+}
+
+.transition-block svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: drop-shadow(0 -12px 28px rgba(0, 0, 0, 0.18));
+}
+
+@media (max-width: 640px) {
+  .transition-block {
+    margin-top: -2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .transition-block {
+    margin-top: -4rem;
+  }
+}
+
 .section-card {
   background-color: #ffffff;
   border-radius: 1rem;

--- a/index.html
+++ b/index.html
@@ -242,27 +242,29 @@
       </div>
     </section>
 
-    <div class="relative -mt-6 h-16 overflow-hidden" aria-hidden="true">
-      <svg
-        class="absolute inset-0 h-full w-full"
-        viewBox="0 0 1440 160"
-        xmlns="http://www.w3.org/2000/svg"
-        preserveAspectRatio="none"
-      >
-        <defs>
-          <linearGradient id="manifesto-wave" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="rgba(9, 9, 11, 0.4)" />
-            <stop offset="100%" stop-color="#ffffff" />
-          </linearGradient>
-        </defs>
+    <div class="transition-block" aria-hidden="true">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 200" preserveAspectRatio="none">
         <path
-          d="M0 80L60 74.7C120 69 240 58 360 58.7C480 59 600 74 720 80C840 86 960 80 1080 74.7C1200 69 1320 64 1380 61.3L1440 58V160H1380C1320 160 1200 160 1080 160C960 160 840 160 720 160C600 160 480 160 360 160C240 160 120 160 60 160H0Z"
-          fill="url(#manifesto-wave)"
+          fill="#ffffff"
+          d="M0 200V80L220 60L620 110L960 50L1440 90V200Z"
+        />
+        <path
+          fill="#f5f5f5"
+          d="M0 200V140L420 90L220 200Z"
+        />
+        <path
+          fill="#f1f1f1"
+          d="M1440 200V150L980 80L1210 200Z"
+        />
+        <path
+          fill="#ebebeb"
+          d="M620 110L880 200H420Z"
+          opacity="0.7"
         />
       </svg>
     </div>
 
-    <section id="conteudos-destaque" class="bg-white pt-16 pb-12" aria-labelledby="conteudos-heading">
+    <section id="conteudos-destaque" class="bg-white pt-10 pb-12 lg:pt-16" aria-labelledby="conteudos-heading">
       <div class="mx-auto max-w-6xl px-4 lg:px-8">
         <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div>


### PR DESCRIPTION
## Summary
- replace the manifesto-to-featured cut with a full-width diagonal SVG transition that uses the site's neutral palette
- adjust spacing around the featured content heading for consistent top padding
- add responsive styles so the transition block overlays cleanly on mobile and desktop

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da920f06fc83289b4fbabf172753b4