### PR TITLE
Add gradient transition between manifesto and featured content sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,22 @@
       animation: newsletter-confetti 1.4s ease-out forwards;
       animation-delay: var(--confetti-delay, 0s);
     }
+
+    .manifesto-conteudos-transition {
+      height: 6rem;
+      background: linear-gradient(
+        to bottom,
+        rgba(9, 9, 11, 0.85),
+        rgba(9, 9, 11, 0.65) 40%,
+        rgba(255, 255, 255, 0.92) 100%
+      );
+    }
+
+    @media (min-width: 1024px) {
+      .manifesto-conteudos-transition {
+        height: 7.5rem;
+      }
+    }
   </style>
 </head>
 <body class="bg-muted font-sans text-slate-900" data-analytics="site-paradigma">
@@ -242,27 +258,7 @@
       </div>
     </section>
 
-    <div class="transition-block" aria-hidden="true">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 200" preserveAspectRatio="none">
-        <path
-          fill="#ffffff"
-          d="M0 200V80L220 60L620 110L960 50L1440 90V200Z"
-        />
-        <path
-          fill="#f5f5f5"
-          d="M0 200V140L420 90L220 200Z"
-        />
-        <path
-          fill="#f1f1f1"
-          d="M1440 200V150L980 80L1210 200Z"
-        />
-        <path
-          fill="#ebebeb"
-          d="M620 110L880 200H420Z"
-          opacity="0.7"
-        />
-      </svg>
-    </div>
+    <div class="manifesto-conteudos-transition" aria-hidden="true"></div>
 
     <section id="conteudos-destaque" class="bg-white pt-10 pb-12 lg:pt-16" aria-labelledby="conteudos-heading">
       <div class="mx-auto max-w-6xl px-4 lg:px-8">


### PR DESCRIPTION
## Summary
- replace the decorative SVG separator with a linear-gradient transition between the manifesto and featured content sections
- adjust the transition height responsively to keep the gradient smooth on desktop and mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9b34be4c83288627762d8d3d9d0d