### PR TITLE
Remove transition gradient between manifesto and featured content

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,21 +85,6 @@
       animation-delay: var(--confetti-delay, 0s);
     }
 
-    .manifesto-conteudos-transition {
-      height: 6rem;
-      background: linear-gradient(
-        to bottom,
-        rgba(9, 9, 11, 0.85),
-        rgba(9, 9, 11, 0.65) 40%,
-        rgba(255, 255, 255, 0.92) 100%
-      );
-    }
-
-    @media (min-width: 1024px) {
-      .manifesto-conteudos-transition {
-        height: 7.5rem;
-      }
-    }
   </style>
 </head>
 <body class="bg-muted font-sans text-slate-900" data-analytics="site-paradigma">
@@ -257,8 +242,6 @@
         </div>
       </div>
     </section>
-
-    <div class="manifesto-conteudos-transition" aria-hidden="true"></div>
 
     <section id="conteudos-destaque" class="bg-white pt-10 pb-12 lg:pt-16" aria-labelledby="conteudos-heading">
       <div class="mx-auto max-w-6xl px-4 lg:px-8">


### PR DESCRIPTION
## Summary
- remove the transitional gradient element and styles between the manifesto and featured content sections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da9d50b5948328b80d00ea2d2ec23a