### PR TITLE
Move Experimentar heading outside quiz card

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,29 +292,33 @@
     <div class="h-24 bg-gradient-to-b from-white to-muted" aria-hidden="true"></div>
 
     <section class="mx-auto max-w-5xl px-4 pb-12 pt-8 sm:pt-16 sm:pb-12 lg:px-8" aria-labelledby="reflexao-heading">
-      <div class="rounded-3xl bg-background px-6 py-10 text-white shadow-lg sm:px-8 sm:py-12">
-        <div class="text-center">
+      <div class="space-y-6">
+        <div>
           <p class="font-semibold uppercase tracking-[0.3em] text-accent">Experimentar</p>
-          <h2 id="reflexao-heading" class="mt-4 font-display text-4xl uppercase text-white">O que seu corpo ancestral faria diante do mundo moderno?</h2>
+          <h2 id="reflexao-heading" class="font-display text-4xl uppercase text-background">O que seu corpo ancestral faria diante do mundo moderno?</h2>
         </div>
-        <p class="mt-6 text-center text-white/80">Responda às perguntas para revelar o instinto que guiaria sua evolução.</p>
-        <p class="mt-2 text-center text-base font-medium text-white">Cada escolha soma pontos e monta o seu perfil biológico evolutivo.</p>
-        <div class="mt-8 space-y-6" data-quiz>
-          <div class="space-y-4" data-quiz-content>
-            <p class="text-center text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
-              Pergunta <span data-quiz-progress>1</span> de <span data-quiz-total>5</span>
-            </p>
-            <h3 class="text-center font-display text-2xl font-normal text-white sm:text-3xl" data-quiz-question>
-              O que seu corpo ancestral faria diante do mundo moderno?
-            </h3>
-            <div class="mt-6 flex flex-col gap-4 sm:grid sm:grid-cols-3" data-quiz-options role="group" aria-label="Opções do quiz"></div>
+        <div class="rounded-3xl bg-background px-6 py-10 text-white shadow-lg sm:px-8 sm:py-12">
+          <div class="text-center">
+            <p class="mt-6 text-center text-white/80">Responda às perguntas para revelar o instinto que guiaria sua evolução.</p>
+            <p class="mt-2 text-center text-base font-medium text-white">Cada escolha soma pontos e monta o seu perfil biológico evolutivo.</p>
           </div>
-          <button
-            type="button"
-            class="focus-visible hidden w-full rounded-full border border-white/40 px-6 py-3 text-center font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10"
-            data-quiz-result-button
-          >Ver resultado</button>
-          <div class="mt-6 hidden min-h-[4rem] rounded-2xl bg-white/10 p-6 text-center text-sm text-white/90" data-quiz-result aria-live="polite"></div>
+          <div class="mt-8 space-y-6" data-quiz>
+            <div class="space-y-4" data-quiz-content>
+              <p class="text-center text-xs font-semibold uppercase tracking-[0.35em] text-white/60">
+                Pergunta <span data-quiz-progress>1</span> de <span data-quiz-total>5</span>
+              </p>
+              <h3 class="text-center font-display text-2xl font-normal text-white sm:text-3xl" data-quiz-question>
+                O que seu corpo ancestral faria diante do mundo moderno?
+              </h3>
+              <div class="mt-6 flex flex-col gap-4 sm:grid sm:grid-cols-3" data-quiz-options role="group" aria-label="Opções do quiz"></div>
+            </div>
+            <button
+              type="button"
+              class="focus-visible hidden w-full rounded-full border border-white/40 px-6 py-3 text-center font-semibold uppercase tracking-[0.2em] transition hover:bg-white/10"
+              data-quiz-result-button
+            >Ver resultado</button>
+            <div class="mt-6 hidden min-h-[4rem] rounded-2xl bg-white/10 p-6 text-center text-sm text-white/90" data-quiz-result aria-live="polite"></div>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- move the Experimentar section heading outside the quiz container
- reuse the featured content heading styling for the Experimentar title to align with other sections

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daa0c6dd7c8328bd3f6cb18843b0e1