### PR TITLE
Adjust mobile spacing for reflexão section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -70,6 +70,12 @@ header {
   }
 }
 
+@media (max-width: 768px) {
+  section[aria-labelledby="reflexao-heading"] {
+    padding-top: 1.5rem;
+  }
+}
+
 .section-card {
   background-color: #ffffff;
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- reduce the top padding of the reflexão section on mobile viewports via a media query to refine spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa5a964a883289b2b4b88d7357bca