### PR TITLE
Restore assets to the Move experimentar heading commit state

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -70,12 +70,6 @@ header {
   }
 }
 
-@media (max-width: 768px) {
-  section[aria-labelledby="reflexao-heading"] {
-    padding-top: 1.5rem;
-  }
-}
-
 .section-card {
   background-color: #ffffff;
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- revert the mobile-specific padding adjustments for the Experimentar section so assets match commit ecac199

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68daaae1cec4832884ee3577534e769e