### PR TITLE
Padroniza hero de sobre.html e manifesto.html com padrão SOMA

### DIFF
--- a/manifesto.html
+++ b/manifesto.html
@@ -87,14 +87,14 @@
 
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO MANIFESTO HERO -->
-    <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative w-full">
-        <img src="/assets/img/hero-overlay.svg" alt="Formas abstratas em verde e preto" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex max-w-5xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
-          <p class="font-semibold uppercase tracking-[0.3em] text-accent">Manifesto</p>
-          <h1 class="font-display text-5xl uppercase leading-tight">No que acreditamos...</h1>
-          <p class="max-w-2xl text-lg text-foreground/80">Uma declaração viva que orienta nossas decisões coletivas, respeitando a complexidade da vida e celebrando o potencial humano.</p>
+    <section class="soma-hero" aria-labelledby="hero-heading">
+      <div class="soma-hero__overlay" aria-hidden="true"></div>
+      <div class="soma-hero__content">
+        <div class="soma-hero__label">
+          <span class="soma-pill">manifesto</span>
         </div>
+        <h1 id="hero-heading" class="soma-hero__title font-display">No que acreditamos...</h1>
+        <p class="soma-hero__subtitle">Uma declaração viva que orienta nossas decisões coletivas, respeitando a complexidade da vida e celebrando o potencial humano.</p>
       </div>
     </section>
     <!-- FIM BLOCO MANIFESTO HERO -->

--- a/sobre.html
+++ b/sobre.html
@@ -87,14 +87,14 @@
 
   <main id="conteudo-principal">
     <!-- INÍCIO BLOCO HERO SOBRE -->
-    <section class="relative overflow-hidden bg-background text-foreground">
-      <div class="hero-overlay relative w-full">
-        <img src="/assets/img/hero-overlay.svg" alt="Formas abstratas representando colaboração" class="absolute inset-0 h-full w-full" />
-        <div class="relative mx-auto flex max-w-6xl flex-col justify-center gap-4 px-4 py-20 sm:py-24 lg:px-8 lg:py-20">
-          <p class="font-semibold uppercase tracking-[0.3em] text-accent">Sobre nós</p>
-          <h1 class="font-display text-5xl uppercase leading-tight">Sobre a Paradigma</h1>
-          <p class="max-w-3xl text-lg text-foreground/80">Somos apaixonados por movimento, esportes, cultura e acima de tudo pela vida! </p>
+    <section class="soma-hero" aria-labelledby="hero-heading">
+      <div class="soma-hero__overlay" aria-hidden="true"></div>
+      <div class="soma-hero__content">
+        <div class="soma-hero__label">
+          <span class="soma-pill">sobre nós</span>
         </div>
+        <h1 id="hero-heading" class="soma-hero__title font-display">Sobre a Paradigma</h1>
+        <p class="soma-hero__subtitle">Somos apaixonados por movimento, esportes, cultura e acima de tudo pela vida!</p>
       </div>
     </section>
     <!-- FIM BLOCO HERO SOBRE -->


### PR DESCRIPTION
### Motivation
- Uniformizar o início (hero) das páginas `sobre.html` e `manifesto.html` para usar o mesmo sistema visual do hero em `SOMA.html` (fundo escuro com overlay, tipografia, pill/eyebrow e ritmo de espaçamento).
- Reaproveitar as classes e regras já existentes do hero SOMA para evitar mudanças em `styles.css` ou nas variáveis de cor do projeto.
- Eliminar os elementos decorativos antigos (imagem/bolhas) apenas no hero dessas páginas, preservando todo o conteúdo textual.

### Description
- Substituí o markup do hero em `sobre.html` e `manifesto.html` pela estrutura `soma-hero` usada em `SOMA.html`, incluindo `soma-hero__overlay`, `soma-hero__content`, `soma-pill`, `soma-hero__title` e `soma-hero__subtitle`.
- Removi o `img` de overlay e a wrapper `hero-overlay` dos heros antigos, mantendo os textos originais (eyebrow/pill, H1 e subtítulo) sem reescrever o copy.
- Não alterei `assets/css/styles.css` nem variáveis de cor; o ajuste reutiliza diretamente as classes CSS já presentes para o hero SOMA.
- As alterações foram limitadas ao HTML dos blocos hero das duas páginas e não tocam no header/nav, outras seções, nem em JS.

### Testing
- Levantei um servidor estático com `python -m http.server 8000` e verifiquei as páginas localmente com um script Playwright que captura screenshots automatizadas; o script gerou `artifacts/sobre-hero.png` e `artifacts/manifesto-hero.png` com sucesso.
- O processo de alteração foi commitado (`Padroniza heros de sobre e manifesto`) e o commit foi aplicado sem erros.
- Não foram executados testes unitários automatizados porque as mudanças são de conteúdo estático/CSS reutilizado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614c0388388328b4b3e8a691396d8f)